### PR TITLE
feature: hide on empty

### DIFF
--- a/.github/workflows/test-comment-inputs.yaml
+++ b/.github/workflows/test-comment-inputs.yaml
@@ -117,3 +117,54 @@ jobs:
           update-mode: "create"
           verbose-logging: true
     
+  # Tests that hide-on-empty doesn't create an initial comment if comment-body is empty.
+  test_hide_on_empty_no_comment_body:
+    name: Test Hide On Empty No Comment Body
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    continue-on-error: true
+    if: contains(github.event.pull_request.labels.*.name, 'test-inputs')
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Comment On PR With Empty Comment Body
+        uses: ./
+        id: comment-hide-on-empty-empty-comment-body-intial
+        with:
+          comment-id: "test-hide-on-empty-empty-comment-body"
+          comment-body: ""
+          conclusion: "success"
+          update-mode: "create"
+          verbose-logging: true
+          hide-on-empty: true
+
+  # Tests that hide-on-empty doesn't create an initial comment if the file at comment-body-path is empty.
+  test_hide_on_empty_no_comment_body_path:
+    name: Test Hide On Empty With Empty Comment Body Path
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    continue-on-error: true
+    if: contains(github.event.pull_request.labels.*.name, 'test-inputs')
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Load Environment Variables From .env File
+        run: |
+          grep '^COMMENT_BODY_PATH_3=' ci/vars/test.env >> $GITHUB_ENV
+
+      - name: Comment On PR With Empty Comment Body Path
+        uses: ./
+        id: comment-hide-on-empty-empty-comment-body-path-intial
+        with:
+          comment-id: "test-hide-on-empty-empty-comment-body-path"
+          comment-body-path: ${{ env.COMMENT_BODY_PATH_3 }}
+          conclusion: "success"
+          update-mode: "create"
+          verbose-logging: true
+          hide-on-empty: true

--- a/.github/workflows/test-comment-update-mode.yaml
+++ b/.github/workflows/test-comment-update-mode.yaml
@@ -140,7 +140,7 @@ jobs:
       contents: read
       pull-requests: write
     continue-on-error: true
-    if: contains(github.event.pull_request.labels.*.name, 'test-inputs')
+    if: contains(github.event.pull_request.labels.*.name, 'test-update-mode')
     steps:
       - name: Checkout Repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
@@ -175,7 +175,7 @@ jobs:
       contents: read
       pull-requests: write
     continue-on-error: true
-    if: contains(github.event.pull_request.labels.*.name, 'test-inputs')
+    if: contains(github.event.pull_request.labels.*.name, 'test-update-mode')
     steps:
       - name: Checkout Repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
@@ -210,7 +210,7 @@ jobs:
       contents: read
       pull-requests: write
     continue-on-error: true
-    if: contains(github.event.pull_request.labels.*.name, 'test-inputs')
+    if: contains(github.event.pull_request.labels.*.name, 'test-update-mode')
     steps:
       - name: Checkout Repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0

--- a/.github/workflows/test-comment-update-mode.yaml
+++ b/.github/workflows/test-comment-update-mode.yaml
@@ -131,3 +131,114 @@ jobs:
           comment-body: "test update none - updated comment"
           conclusion: "success"
           update-mode: "none"
+
+  # Tests that hide-on-empty hides an existing comment if the comment-body is empty - update mode append.
+  test_update_hide_on_empty_no_comment_body_append:
+    name: Test Update Hide On Empty No Comment Body Append
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    continue-on-error: true
+    if: contains(github.event.pull_request.labels.*.name, 'test-inputs')
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Make Initial Comment With Hide On Empty
+        uses: ./
+        id: comment-hide-on-empty-empty-comment-body-update-intial-append
+        with:
+          comment-id: "test-update-hide-on-empty-empty-comment-body"
+          comment-body: "test hide on empty - initial comment"
+          conclusion: "success"
+          update-mode: "append"
+          verbose-logging: true
+          hide-on-empty: true
+
+      - name: Update Comment With Hide On Empty
+        uses: ./
+        id: comment-hide-on-empty-empty-comment-body-update-append
+        with:
+          comment-id: "test-update-hide-on-empty-empty-comment-body"
+          comment-body: ""
+          conclusion: "success"
+          update-mode: "append"
+          verbose-logging: true
+          hide-on-empty: true
+
+  # Tests that hide-on-empty hides an existing comment if the comment-body is empty - update mode create.
+  test_update_hide_on_empty_no_comment_body_create:
+    name: Test Update Hide On Empty No Comment Body Create
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    continue-on-error: true
+    if: contains(github.event.pull_request.labels.*.name, 'test-inputs')
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Make Initial Comment With Hide On Empty
+        uses: ./
+        id: comment-hide-on-empty-empty-comment-body-update-intial-create
+        with:
+          comment-id: "test-update-hide-on-empty-empty-comment-body"
+          comment-body: "test hide on empty - initial comment"
+          conclusion: "success"
+          update-mode: "create"
+          verbose-logging: true
+          hide-on-empty: true
+
+      - name: Update Comment With Hide On Empty
+        uses: ./
+        id: comment-hide-on-empty-empty-comment-body-update-create
+        with:
+          comment-id: "test-update-hide-on-empty-empty-comment-body"
+          comment-body: ""
+          conclusion: "success"
+          update-mode: "create"
+          verbose-logging: true
+          hide-on-empty: true
+
+  # Tests that hide-on-empty hides an existing comment if the file at comment-body-path is empty - update mode replace.
+  test_update_hide_on_empty_no_comment_body_path:
+    name: Test Update Hide On Empty With Empty Comment Body Path
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    continue-on-error: true
+    if: contains(github.event.pull_request.labels.*.name, 'test-inputs')
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+
+      - name: Load Environment Variables From .env File
+        run: |
+          grep '^COMMENT_BODY_PATH_2=' ci/vars/test.env >> $GITHUB_ENV
+          grep '^COMMENT_BODY_PATH_3=' ci/vars/test.env >> $GITHUB_ENV
+
+      - name: Make Initial Comment With Hide On Empty
+        uses: ./
+        id: comment-hide-on-empty-empty-comment-body-path-update-intial
+        with:
+          comment-id: "test-update-hide-on-empty-empty-comment-body-path"
+          comment-body-path: ${{ env.COMMENT_BODY_PATH_2 }}
+          conclusion: "success"
+          update-mode: "create"
+          verbose-logging: true
+          hide-on-empty: true
+
+      - name: Update Comment With Hide On Empty
+        uses: ./
+        id: comment-hide-on-empty-empty-comment-body-path-update-replace
+        with:
+          comment-id: "test-update-hide-on-empty-empty-comment-body-path"
+          comment-body-path: ${{ env.COMMENT_BODY_PATH_3 }}
+          conclusion: "success"
+          update-mode: "replace"
+          verbose-logging: true
+          hide-on-empty: true
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # CHANGELOG
+## [1.2.0] - 2026-02-17
+### Don't Comment/Hide if Empty
+#### Added
+- `hide-on-empty` input added (default is `true`) which controls whether the comment should be hidden if the `comment-body` or `comment-body-path` is empty
+#### Changed
+- `conclusion` input is now 'optional'. However it will be required if `sync-conclusion` is enabled as that input is dependent on `conclusion`
+
 ## [1.1.0] - 2025-11-14
 ### Comment-Body and Comment-Body-Path Truly 'Optional'
 #### Changed
@@ -7,10 +14,10 @@
 ## [1.0.0] - 2025-10-31
 ### Full Public Release
 #### Added
-- `render-markdown` flag added (default is `true`) which controls whether the comment body should be rendered as markdown or not. Useful for files like terraform plans which might not want to be rendered as markdown
+- `render-markdown` input added (default is `true`) which controls whether the comment body should be rendered as markdown or not. Useful for files like terraform plans which might not want to be rendered as markdown
 - Apache 2.0 license
 #### Changed
-- `on-resolution-hide` flag is now called `sync-conclusion`. Functionality is the same
+- `on-resolution-hide` input is now called `sync-conclusion`. Functionality is the same
 - Runners changed from `colpal` internal to `ubuntu-latest`
 - Restructured the test workflow to be more modular and done via manual triggers
 #### Removed
@@ -24,7 +31,7 @@
 - Corrected documentation to note that `verbose-logging` and `on-resolution-hide` accept booleans, and not string-wrapped booleans 
 
 ## [0.4.0] - 2025-10-02
-### Removing status checks
+### Removing Status Checks
 #### Added
 - Adding pagination support on finding comments
   - Resolves an issue where if there were more than 100 comments on a pull request, this action may have trouble finding a previous one to hide or update
@@ -42,9 +49,9 @@
   - This is intended for use cases that align with the common `conclusion` pattern: `conclusion: ${{ steps.previous-step.outcome }}`
 
 ## [0.2.0] - 2025-09-25
-### On-Resolution-Hide Input
+### On-Resolution-Hide Flag
 #### Added
-- `on-resolution-hide` input added (default is `false` (off))
+- `on-resolution-hide` flag added (default is `false` (off))
   - When enabled, will hide comments automatically once its conclusion is `success`
 
 ## [0.1.0] - 2025-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # CHANGELOG
-## [1.2.0] - 2026-02-17
+## [1.2.0] - 2026-02-20
 ### Don't Comment/Hide if Empty
 #### Added
 - `hide-on-empty` input added (default is `true`) which controls whether the comment should be hidden if the `comment-body` or `comment-body-path` is empty

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ All inputs for this action are summarized below for quick reference:
 | `comment-id`        | string | —                      | Yes       | Unique identifier for the comment/check.                                                     |
 | `comment-body`      | string | —                      | No        | Text to use as the comment body.
 | `comment-body-path` | string | —                      | No        | Path to markdown file for comment body.
-| `conclusion`        | string | —                      | Yes       | Workflow result: `success`, `failure`, `skipped`, or `cancelled`.                           |
+| `conclusion`        | string | —                      | No       | Workflow result: `success`, `failure`, `skipped`, or `cancelled`.                           |
 | `github-token`      | string | `${{ github.token }}`  | No        | GitHub token used by `github-actions[bot]` to leave comments.                                                   |
+| `hide-on-empty` | boolean | `true` | No | Hide previous comment if `comment-body` or `comment-body-path` is supplied but empty. Do not create a new comment. |
 | `render-markdown`   | boolean | `true`                 | No        | Render the comment body as markdown.                                                     |
 | `sync-conclusion`| boolean | `false`                | No        | Hide previous failure comment when resolved. If the initial comment is `conclusion: success` and this is set to `true`, then the comment will not be created.                                       |
 | `update-mode`       | string | `"create"`               | No        | How to handle existing comments: `replace`, `append`, `create`, or `none`.                   |
@@ -75,7 +76,7 @@ The `comment-body-path` input is the path to a markdown file for the comment bod
 Both fields cannot be supplied at once. If both are supplied, the action will fail. However, neither field can be supplied and then an empty comment will be generated
 
 ## Conclusion
-The `conclusion` input is a hidden identifier that tracks the status of the current run. It works with [`sync-conclusion`](#sync-conclusion) to control comment visibility. Use `steps.<step_id>.outcome` for this value. Possible values and their effects:
+The `conclusion` input is a hidden identifier that tracks the status of the current run. It works with [`sync-conclusion`](#sync-conclusion) to control comment visibility. **While `conclusion` is not required, it becomes required if `sync-conclusion` is used.** Use `steps.<step_id>.outcome` for this value. Possible values and their effects:
 
 | Value      | Effect                                                                                   |
 |------------|-----------------------------------------------------------------------------------------|
@@ -84,8 +85,14 @@ The `conclusion` input is a hidden identifier that tracks the status of the curr
 | `skipped`  | Sets hidden identifier to `skipped`. No new comment created/updated. May hide existing. |
 | `cancelled`| Sets hidden identifier to `cancelled`. No new comment created/updated.                  |
 
+## Hide-On-Empty
+The `hide-on-empty` input controls whether the comment should be hidden if the `comment-body` or `comment-body-path` is empty. This provides a mechanism to hide comments without the knowledge of a `conclusion`. Calling workflows can be configured in such a way that it will supply an empty body when the action should not create a comment. 
+
+- If `true`, then no new comment will be created if the `comment-body` or `comment-body-path` is empty, and any previous comment will also be hidden. 
+- If `false`, then an empty comment will be created as that is what is supplied via the `comment-body` or `comment-body-path`.
+
 ## Render-Markdown
-This flag controls whether the comment body should be rendered as markdown or not. Useful for files like Terraform plans which might not want to be rendered as markdown.
+The `render-markdown` input controls whether the comment body should be rendered as markdown or not. Useful for files like Terraform plans which might not want to be rendered as markdown.
 
 - If `render-markdown` is `true`, the comment body will be rendered as markdown.
   - `**bold**` will be rendered as **bold** instead of `**bold**`.
@@ -93,7 +100,7 @@ This flag controls whether the comment body should be rendered as markdown or no
   - `**bold**` will be rendered as `**bold**` instead of **bold**.
 
 ## Sync-Conclusion
-This flag controls whether successful comments are hidden automatically. When set to `"true"`:
+The `sync-conclusion` input controls whether successful comments are hidden automatically. When set to `"true"`:
 
 - If `conclusion` is `success`, the comment is hidden.
   - If `conclusion` is `success` and it's the **first** comment, then the comment is not created at all.

--- a/action.yaml
+++ b/action.yaml
@@ -13,21 +13,25 @@ inputs:
     required: false
   conclusion:
     description: The conclusion status of the check (can be success, failure, cancelled)
-    required: true
+    required: false
+  hide-on-empty:
+    description: If true, hide the comment when the comment contents are empty
+    required: false
+    default: true
   github-token:
     description: The GitHub token used to create an authenticated client
     required: false
     default: ${{ github.token }}
   render-markdown:
-    description: "If true, render the comment body as markdown."
+    description: If true, render the comment body as markdown
     required: false
     default: true
   sync-conclusion:
-    description: "If true, hide the comment when the conclusion is now 'success' from previous 'failure'."
+    description: "If true, hide the comment when the conclusion is now 'success' from previous 'failure'"
     required: false
     default: false
   update-mode:
-    description: "How to handle existing comments. Options: 'replace' (overwrite), 'append' (add to end), 'create' (always make a new comment)."
+    description: "How to handle existing comments. Options: 'replace' (overwrite), 'append' (add to end), 'create' (always make a new comment)"
     required: false
     default: "create"
   verbose-logging:

--- a/ci/vars/test.env
+++ b/ci/vars/test.env
@@ -3,6 +3,7 @@ CHECK_NAME_2=comment-file
 COMMENT_BODY=*in-line* **comment** markdown acceptable comment ~~!~~
 COMMENT_BODY_PATH_1=tests/markdown-comments/test-comment-1.md
 COMMENT_BODY_PATH_2=tests/markdown-comments/test-comment-2.md
+COMMENT_BODY_PATH_3=tests/markdown-comments/test-comment-3.md
 CONCLUSION=success
 UPDATE_MODE_1=create
 UPDATE_MODE_2=append

--- a/dist/index.js
+++ b/dist/index.js
@@ -23993,6 +23993,10 @@ var require_util8 = __commonJS({
           if (fileContent.charCodeAt(0) === 65279) {
             fileContent = fileContent.slice(1);
           }
+          if (fileContent === "") {
+            logger.debug("Comment body path's file is empty.");
+            return "";
+          }
           return renderCommentBody(fileContent);
         } catch (error) {
           throw new Error(`Could not read file at path: ${commentPath}. Error: ${error.message}`);
@@ -24005,7 +24009,6 @@ var require_util8 = __commonJS({
       }
     }
     function renderCommentBody(commentBody) {
-      logger.debug("IN RENDER");
       if (core.getInput("render-markdown", { required: false }) === "true") {
         logger.debug("Rendering comment body as markdown enabled.");
         return commentBody;
@@ -24064,6 +24067,7 @@ var require_update_comment = __commonJS({
         body: commentBody
       });
       logger.debug("Comment updated successfully.");
+      return newCommentBody;
     }
     module2.exports = { updateComment };
   }
@@ -24127,9 +24131,16 @@ var require_post_comment = __commonJS({
     var { getCommentBody } = require_util8();
     var github = require_github();
     var { logger } = require_logger();
-    async function postComment(octokit, owner, repo, commentIdentifier, conclusionIdentifier) {
+    async function postComment(octokit, owner, repo, commentIdentifier, conclusionIdentifier, hideOnEmpty) {
       logger.info("Starting to post a comment...");
-      const commentBody = commentIdentifier + "\n" + conclusionIdentifier + "\n" + getCommentBody();
+      let commentBody = getCommentBody();
+      logger.debug("Comment Body: ", commentBody);
+      logger.debug("Hide On Empty: ", hideOnEmpty);
+      if (commentBody === "" && hideOnEmpty) {
+        logger.debug("Comment body is empty. Skipping comment post.");
+        return;
+      }
+      commentBody = commentIdentifier + "\n" + conclusionIdentifier + "\n" + commentBody;
       const prNumber = github.context.payload.pull_request.number;
       if (!prNumber) {
         logger.warning("Not a pull request, skipping review submission.");
@@ -24161,7 +24172,8 @@ var require_comment_workflow = __commonJS({
     async function commentWorkflow2(token) {
       const octokit = github.getOctokit(token);
       const { owner, repo } = github.context.repo;
-      const conclusion = core.getInput("conclusion", { required: true });
+      const conclusion = core.getInput("conclusion", { required: false }) || "";
+      const hideOnEmpty = (core.getInput("hide-on-empty", { required: false }) || "true") === "true";
       if (conclusion === "cancelled") {
         logger.debug("Conclusion is 'cancelled', skipping comment workflow.");
         return;
@@ -24179,7 +24191,7 @@ var require_comment_workflow = __commonJS({
             logger.debug("New comment not posted due to success conclusion and sync-conclusion being true.");
           } else {
             logger.debug("No existing comment found, posting a new comment.");
-            comment = await postComment(octokit, owner, repo, commentIdentifier, conclusionIdentifier);
+            comment = await postComment(octokit, owner, repo, commentIdentifier, conclusionIdentifier, hideOnEmpty);
           }
         } else {
           const updateMode = core.getInput("update-mode", { required: false }) || "create";
@@ -24195,21 +24207,25 @@ var require_comment_workflow = __commonJS({
           if (updateMode === "create") {
             await hideComment(token, comment, "OUTDATED");
             logger.debug("Existing comment hidden as OUTDATED. Posting a new comment.");
-            await postComment(octokit, owner, repo, commentIdentifier, conclusionIdentifier);
+            await postComment(octokit, owner, repo, commentIdentifier, conclusionIdentifier, hideOnEmpty);
             logger.debug("New comment posted successfully.");
           } else if (updateMode === "none") {
             logger.debug("Update mode is 'none', skipping comment update.");
           } else {
-            await updateComment(octokit, owner, repo, comment, commentIdentifier, updateMode, conclusionIdentifier);
+            const commentToUpdateWith = await updateComment(octokit, owner, repo, comment, commentIdentifier, updateMode, conclusionIdentifier);
             logger.debug("Existing comment updated successfully.");
-            if (core.getInput("sync-conclusion", { required: false }) === "true") {
+            if (commentToUpdateWith === "" && hideOnEmpty) {
+              logger.debug("Comment body is empty and hide-on-empty is true. Hiding comment.");
+              await hideComment(token, comment, "OUTDATED");
+            } else if (core.getInput("sync-conclusion", { required: false }) === "true") {
               if (conclusion === "success") {
                 await hideComment(token, comment, "RESOLVED");
                 logger.debug("Existing comment hidden as RESOLVED due to success conclusion.");
-              }
-              if (conclusion === "failure") {
+              } else if (conclusion === "failure") {
                 await unhideComment(token, comment);
                 logger.debug("Existing comment unhidden due to failure conclusion.");
+              } else {
+                logger.debug("Conclusion is not 'success' or 'failure', cannot properly sync-conclusion.");
               }
             }
           }

--- a/src/comment/comment-workflow.js
+++ b/src/comment/comment-workflow.js
@@ -12,10 +12,12 @@ const { logger } = require('../util/logger.js');
  *
  * This function finds or creates a PR comment identified by the check name,
  * and then determines how to handle the comment based on its existence and the update mode:
- *   - If no existing comment is found, a new comment is posted.
+ *   - If no existing comment is found, a new comment is posted (unless hideOnEmpty is true and body is empty OR sync-conclusion is true and conclusion is success).
  *   - If a comment exists:
  *       - If update mode is "create", the existing comment is hidden as "OUTDATED" and a new comment is posted.
  *       - Otherwise, the existing comment is updated according to the specified update mode.
+ *       - If the updated comment body is empty and hideOnEmpty is true, the comment is hidden as "OUTDATED".
+ *       - If sync-conclusion is enabled, comments are hidden/unhidden based on the conclusion status.
  *
  * @async
  * @param {string} token - GitHub authentication token.
@@ -24,7 +26,8 @@ const { logger } = require('../util/logger.js');
 async function commentWorkflow(token) {
     const octokit = github.getOctokit(token);
     const { owner, repo } = github.context.repo;
-    const conclusion = core.getInput('conclusion', { required: true });
+    const conclusion = core.getInput('conclusion', { required: false }) || "";
+    const hideOnEmpty = (core.getInput('hide-on-empty', { required: false }) || "true") === "true";
 
     if (conclusion === 'cancelled') {
         logger.debug("Conclusion is 'cancelled', skipping comment workflow.");
@@ -46,10 +49,9 @@ async function commentWorkflow(token) {
                 return;
             } else if (core.getInput('sync-conclusion', { required: false }) === 'true' && conclusion === 'success') {
                 logger.debug("New comment not posted due to success conclusion and sync-conclusion being true.");
-            }
-            else {
+            } else {
                 logger.debug("No existing comment found, posting a new comment.");
-                comment = await postComment(octokit, owner, repo, commentIdentifier, conclusionIdentifier);
+                comment = await postComment(octokit, owner, repo, commentIdentifier, conclusionIdentifier, hideOnEmpty);
             }
 
         } else {
@@ -70,26 +72,27 @@ async function commentWorkflow(token) {
             if (updateMode === "create") {
                 await hideComment(token, comment, "OUTDATED");
                 logger.debug("Existing comment hidden as OUTDATED. Posting a new comment.");
-                await postComment(octokit, owner, repo, commentIdentifier, conclusionIdentifier);
+                await postComment(octokit, owner, repo, commentIdentifier, conclusionIdentifier, hideOnEmpty);
                 logger.debug("New comment posted successfully.");
-            }
-            else if (updateMode === "none") {
+            } else if (updateMode === "none") {
                 logger.debug("Update mode is 'none', skipping comment update.");
-            }
-            else {
-                await updateComment(octokit, owner, repo, comment, commentIdentifier, updateMode, conclusionIdentifier);
+            } else {
+                const commentToUpdateWith = await updateComment(octokit, owner, repo, comment, commentIdentifier, updateMode, conclusionIdentifier);
                 logger.debug("Existing comment updated successfully.");
 
-                if (core.getInput('sync-conclusion', { required: false }) === 'true') {
+                if (commentToUpdateWith === "" && hideOnEmpty) {
+                    logger.debug("Comment body is empty and hide-on-empty is true. Hiding comment.");
+                    await hideComment(token, comment, "OUTDATED");
+                } else if (core.getInput('sync-conclusion', { required: false }) === 'true') {
 
                     if (conclusion === 'success') {
                         await hideComment(token, comment, "RESOLVED");
                         logger.debug("Existing comment hidden as RESOLVED due to success conclusion.");
-                    }
-
-                    if (conclusion === 'failure') {
+                    } else if (conclusion === 'failure') {
                         await unhideComment(token, comment);
                         logger.debug("Existing comment unhidden due to failure conclusion.");
+                    } else {
+                        logger.debug("Conclusion is not 'success' or 'failure', cannot properly sync-conclusion.");
                     }
 
                 }

--- a/src/comment/post-comment.js
+++ b/src/comment/post-comment.js
@@ -26,6 +26,9 @@ async function postComment(octokit, owner, repo, commentIdentifier, conclusionId
 
     let commentBody = getCommentBody();
 
+    logger.debug("Comment Body: ", commentBody);
+    logger.debug("Hide On Empty: ", hideOnEmpty);
+
     if (commentBody === "" && hideOnEmpty) {
         logger.debug("Comment body is empty. Skipping comment post.");
         return;

--- a/src/comment/post-comment.js
+++ b/src/comment/post-comment.js
@@ -6,6 +6,10 @@ const { logger } = require('../util/logger.js');
 /**
  * Posts a comment to a pull request using the provided Octokit instance.
  *
+ * If the comment body is empty and hideOnEmpty is true, the function will skip posting
+ * and return undefined. Otherwise, it constructs the full comment body by prepending
+ * the commentIdentifier and conclusionIdentifier to the comment body, then posts it.
+ *
  * @async
  * @function postComment
  * @param {object} octokit - An authenticated Octokit REST client instance.
@@ -13,11 +17,21 @@ const { logger } = require('../util/logger.js');
  * @param {string} repo - The name of the repository.
  * @param {string} commentIdentifier - A string to identify the comment, prepended to the comment body.
  * @param {string} conclusionIdentifier - A string to identify the conclusion, appended to the comment body.
- * @returns {Promise<void>} Resolves when the comment is posted or skipped if not a pull request.
+ * @param {boolean} hideOnEmpty - Whether to skip posting if the comment body is empty.
+ * @returns {Promise<object|undefined>} Resolves with the created comment data, or undefined if skipped.
+ * @throws {Error} If no pull request number is found in the context.
  */
-async function postComment(octokit, owner, repo, commentIdentifier, conclusionIdentifier) {
+async function postComment(octokit, owner, repo, commentIdentifier, conclusionIdentifier, hideOnEmpty) {
     logger.info("Starting to post a comment...");
-    const commentBody = commentIdentifier + "\n" + conclusionIdentifier + "\n" + getCommentBody();
+
+    let commentBody = getCommentBody();
+
+    if (commentBody === "" && hideOnEmpty) {
+        logger.debug("Comment body is empty. Skipping comment post.");
+        return;
+    }
+
+    commentBody = commentIdentifier + "\n" + conclusionIdentifier + "\n" + commentBody;
 
     const prNumber = github.context.payload.pull_request.number;
 

--- a/src/comment/update-comment.js
+++ b/src/comment/update-comment.js
@@ -6,9 +6,9 @@ const { logger } = require('../util/logger.js');
 /**
  * Updates a GitHub pull request comment with new content.
  *
- * Depending on the updateType, the comment body is either replaced or appended with new content.
- * - "replace": Replaces the comment body with the commentIdentifier and new content.
- * - "append": Appends new content to the existing comment body, separated by a divider and timestamp.
+ * Depending on the updateType, the comment body is either replaced or appended with new content:
+ * - "replace": Replaces the entire comment body with commentIdentifier, conclusionIdentifier, and new content.
+ * - "append": Appends new content to the existing comment body, separated by a divider with timestamp.
  *
  * @async
  * @param {object} octokit - The authenticated Octokit REST client instance.
@@ -18,7 +18,8 @@ const { logger } = require('../util/logger.js');
  * @param {string} commentIdentifier - A string used to identify the comment (used in "replace" mode).
  * @param {string} updateType - The type of update ("replace" or "append").
  * @param {string} conclusionIdentifier - A string to identify the conclusion, appended to the comment body.
- * @returns {Promise<void>} Resolves when the comment is updated or skips if not a pull request.
+ * @returns {Promise<string>} Resolves with the new comment body content retrieved from getCommentBody().
+ * @throws {Error} If no pull request number is found in the context or if updateType is unknown.
  */
 async function updateComment(octokit, owner, repo, comment, commentIdentifier, updateType, conclusionIdentifier) {
     logger.info("Starting to update a comment...");
@@ -60,6 +61,7 @@ async function updateComment(octokit, owner, repo, comment, commentIdentifier, u
         body: commentBody,
     });
     logger.debug("Comment updated successfully.");
+    return newCommentBody;
 }
 
 module.exports = { updateComment };

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -10,14 +10,16 @@ const { logger } = require('../util/logger.js');
  * or via a file specified by the 'comment-body-path' input. Only one of these
  * inputs should be provided at a time.
  * 
- * If both inputs are provided, an error is thrown.
- * If 'comment-body-path' is provided, reads the file content and removes BOM if present.
- * If 'comment-body' is provided, returns its value directly.
- * If neither input is provided, returns an empty string.
+ * Behavior:
+ * - If both inputs are provided, an error is thrown.
+ * - If 'comment-body-path' is provided, reads the file content, removes BOM if present,
+ *   and returns empty string if file is empty (bypassing rendering).
+ * - If 'comment-body' is provided, passes it through renderCommentBody based on 'render-markdown' setting.
+ * - If neither input is provided, returns an empty string.
  * 
  * @throws {Error} If both 'comment-body' and 'comment-body-path' are provided.
  * @throws {Error} If the file at 'comment-body-path' cannot be read.
- * @returns {string} The comment body to be used.
+ * @returns {string} The comment body to be used, either rendered as markdown or wrapped in a <pre> tag.
  */
 function getCommentBody() {
     const directComment = core.getInput('comment-body');
@@ -37,13 +39,21 @@ function getCommentBody() {
                 fileContent = fileContent.slice(1);
             }
 
+            // If the file is empty, return an empty string and bypass rendering which may add a <pre> tag.
+            if (fileContent === "") {
+                logger.debug("Comment body path's file is empty.");
+                return "";
+            }
+
             return renderCommentBody(fileContent);
         } catch (error) {
             throw new Error(`Could not read file at path: ${commentPath}. Error: ${error.message}`);
         }
 
     } else if (directComment) {
+
         return renderCommentBody(directComment);
+
     } else {
         logger.debug("Neither a 'comment-body' or a 'comment-body-path' input was supplied.");
         return "";
@@ -51,8 +61,17 @@ function getCommentBody() {
 
 }
 
+/**
+ * Renders the comment body based on the 'render-markdown' input setting.
+ * 
+ * If 'render-markdown' is set to 'true', returns the comment body as-is to be rendered as markdown.
+ * Otherwise, wraps the comment body in a <pre> tag to display it as plain text.
+ * 
+ * @param {string} commentBody - The raw comment body text to be rendered.
+ * @returns {string} The rendered comment body, either as-is or wrapped in a <pre> tag.
+ */
 function renderCommentBody(commentBody) {
-    logger.debug("IN RENDER");
+
     if (core.getInput('render-markdown', { required: false }) === 'true') {
         logger.debug("Rendering comment body as markdown enabled.");
         return commentBody;

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,7 +13,7 @@
 
 - **Coverage Level:** The latest coverage report shows 100% for lines, statements, branches, and functions across all files.
 - **Test Suite Count:** There are 8 test suites in the project.
-- **Test Count:** The test suite contains a total of 75 individual tests.
+- **Test Count:** The test suite contains a total of 81 individual tests.
 - **Passing Tests:** All tests are currently passing, with no failing or skipped tests.
 - **Recent Changes:** Coverage has been maintained at 100% after recent updates.
 - **Continuous Integration:** Tests and coverage checks are run automatically on each pull request to ensure code quality.

--- a/tests/comment/comment-workflow.test.js
+++ b/tests/comment/comment-workflow.test.js
@@ -107,7 +107,7 @@ describe('comment-workflow', () => {
         await commentWorkflow(token);
 
         expect(hideComment).toHaveBeenCalledWith(token, mockComment, "OUTDATED");
-        expect(postComment).toHaveBeenCalledWith(octokit, owner, repo, '<!-- Test Check -->', conclusionIdentifier);
+        expect(postComment).toHaveBeenCalledWith(octokit, owner, repo, '<!-- Test Check -->', conclusionIdentifier, true);
         expect(updateComment).not.toHaveBeenCalled();
     });
 
@@ -127,7 +127,7 @@ describe('comment-workflow', () => {
         await commentWorkflow(token);
 
         expect(hideComment).toHaveBeenCalledWith(token, mockComment, "OUTDATED");
-        expect(postComment).toHaveBeenCalledWith(octokit, owner, repo, '<!-- Test Check -->', conclusionIdentifier);
+        expect(postComment).toHaveBeenCalledWith(octokit, owner, repo, '<!-- Test Check -->', conclusionIdentifier, true);
         expect(updateComment).not.toHaveBeenCalled();
     });
 
@@ -158,7 +158,7 @@ describe('comment-workflow', () => {
         await expect(commentWorkflow(token)).resolves.toBeUndefined();
 
         expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('No existing comment found, posting a new comment.'));
-        expect(postComment).toHaveBeenCalledWith(octokit, owner, repo, commentIdentifier, conclusionIdentifier);
+        expect(postComment).toHaveBeenCalledWith(octokit, owner, repo, commentIdentifier, conclusionIdentifier, true);
         expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Error occurred during comment workflow: postComment error'));
     });
 
@@ -205,7 +205,7 @@ describe('comment-workflow', () => {
     it('should call hideComment when conclusion is success and sync-conclusion is true', async () => {
         const mockComment = { id: 1, body: 'Existing comment' };
         findComment.mockResolvedValue(mockComment);
-        updateComment.mockResolvedValue();
+        updateComment.mockResolvedValue({ body: 'Updated comment' });
         hideComment.mockResolvedValue();
         core.getInput.mockImplementation((key) => {
             if (key === 'comment-id') return 'Test Check';
@@ -224,7 +224,7 @@ describe('comment-workflow', () => {
     it('should not call hideComment when conclusion is failure and sync-conclusion is true', async () => {
         const mockComment = { id: 1, body: 'Existing comment' };
         findComment.mockResolvedValue(mockComment);
-        updateComment.mockResolvedValue();
+        updateComment.mockResolvedValue({ body: 'Updated comment' });
         hideComment.mockResolvedValue();
         core.getInput.mockImplementation((key) => {
             if (key === 'comment-id') return 'Test Check';
@@ -243,7 +243,7 @@ describe('comment-workflow', () => {
     it('should not call hideComment when sync-conclusion is false', async () => {
         const mockComment = { id: 1, body: 'Existing comment' };
         findComment.mockResolvedValue(mockComment);
-        updateComment.mockResolvedValue();
+        updateComment.mockResolvedValue({ body: 'Updated comment' });
         hideComment.mockResolvedValue();
         core.getInput.mockImplementation((key) => {
             if (key === 'comment-id') return 'Test Check';
@@ -263,7 +263,7 @@ describe('comment-workflow', () => {
     it('should not call unhideComment when conclusion is success and sync-conclusion is true', async () => {
         const mockComment = { id: 1, body: 'Existing comment' };
         findComment.mockResolvedValue(mockComment);
-        updateComment.mockResolvedValue();
+        updateComment.mockResolvedValue({ body: 'Updated comment' });
         unhideComment.mockResolvedValue();
         core.getInput.mockImplementation((key) => {
             if (key === 'comment-id') return 'Test Check';
@@ -282,7 +282,7 @@ describe('comment-workflow', () => {
     it('should not call unhideComment when conclusion is success and sync-conclusion is false', async () => {
         const mockComment = { id: 1, body: 'Existing comment' };
         findComment.mockResolvedValue(mockComment);
-        updateComment.mockResolvedValue();
+        updateComment.mockResolvedValue({ body: 'Updated comment' });
         unhideComment.mockResolvedValue();
         core.getInput.mockImplementation((key) => {
             if (key === 'comment-id') return 'Test Check';
@@ -301,7 +301,7 @@ describe('comment-workflow', () => {
     it('should not call unhideComment when conclusion is failure and sync-conclusion is false', async () => {
         const mockComment = { id: 1, body: 'Existing comment' };
         findComment.mockResolvedValue(mockComment);
-        updateComment.mockResolvedValue();
+        updateComment.mockResolvedValue({ body: 'Updated comment' });
         unhideComment.mockResolvedValue();
         core.getInput.mockImplementation((key) => {
             if (key === 'comment-id') return 'Test Check';
@@ -320,7 +320,7 @@ describe('comment-workflow', () => {
     it('should call unhideComment when conclusion is failure and sync-conclusion is true', async () => {
         const mockComment = { id: 1, body: 'Existing comment' };
         findComment.mockResolvedValue(mockComment);
-        updateComment.mockResolvedValue();
+        updateComment.mockResolvedValue({ body: 'Updated comment' });
         unhideComment.mockResolvedValue();
         core.getInput.mockImplementation((key) => {
             if (key === 'comment-id') return 'Test Check';
@@ -334,63 +334,6 @@ describe('comment-workflow', () => {
 
         expect(unhideComment).toHaveBeenCalledWith(token, mockComment);
         expect(logger.debug).toHaveBeenCalledWith("Existing comment unhidden due to failure conclusion.");
-    });
-
-    it('should not call unhideComment when conclusion is success and sync-conclusion is true', async () => {
-        const mockComment = { id: 1, body: 'Existing comment' };
-        findComment.mockResolvedValue(mockComment);
-        updateComment.mockResolvedValue();
-        unhideComment.mockResolvedValue();
-        core.getInput.mockImplementation((key) => {
-            if (key === 'comment-id') return 'Test Check';
-            if (key === 'update-mode') return 'replace';
-            if (key === 'conclusion') return 'success';
-            if (key === 'sync-conclusion') return 'true';
-            return undefined;
-        });
-
-        await commentWorkflow(token);
-
-        expect(unhideComment).not.toHaveBeenCalled();
-        expect(logger.debug).not.toHaveBeenCalledWith("Existing comment unhidden due to failure conclusion.");
-    });
-
-    it('should call unhideComment when conclusion is failure and sync-conclusion is true', async () => {
-        const mockComment = { id: 1, body: 'Existing comment' };
-        findComment.mockResolvedValue(mockComment);
-        updateComment.mockResolvedValue();
-        unhideComment.mockResolvedValue();
-        core.getInput.mockImplementation((key) => {
-            if (key === 'comment-id') return 'Test Check';
-            if (key === 'update-mode') return 'replace';
-            if (key === 'conclusion') return 'failure';
-            if (key === 'sync-conclusion') return 'true';
-            return undefined;
-        });
-
-        await commentWorkflow(token);
-
-        expect(unhideComment).toHaveBeenCalledWith(token, mockComment);
-        expect(logger.debug).toHaveBeenCalledWith("Existing comment unhidden due to failure conclusion.");
-    });
-
-    it('should not call unhideComment when sync-conclusion is false', async () => {
-        const mockComment = { id: 1, body: 'Existing comment' };
-        findComment.mockResolvedValue(mockComment);
-        updateComment.mockResolvedValue();
-        unhideComment.mockResolvedValue();
-        core.getInput.mockImplementation((key) => {
-            if (key === 'comment-id') return 'Test Check';
-            if (key === 'update-mode') return 'replace';
-            if (key === 'conclusion') return 'failure';
-            if (key === 'sync-conclusion') return 'false';
-            return undefined;
-        });
-
-        await commentWorkflow(token);
-
-        expect(unhideComment).not.toHaveBeenCalled();
-        expect(logger.debug).not.toHaveBeenCalledWith("Existing comment unhidden due to failure conclusion.");
     });
 
     it('should call hideComment and postComment when update-mode is "create"', async () => {
@@ -522,5 +465,123 @@ describe('comment-workflow', () => {
         expect(updateComment).not.toHaveBeenCalled();
         expect(findComment).toHaveBeenCalled();
         expect(logger.debug).toHaveBeenCalledWith("New comment not posted due to success conclusion and sync-conclusion being true.");
+    });
+
+    it('should hide comment after update if the comment body is empty and hide-on-empty is true', async () => {
+        const mockComment = { id: 1, body: 'Existing comment' };
+        findComment.mockResolvedValue(mockComment);
+        hideComment.mockResolvedValue();
+        postComment.mockResolvedValue();
+        updateComment.mockResolvedValue('');
+        core.getInput.mockImplementation((key) => {
+            if (key === 'comment-id') return 'Test Check';
+            if (key === 'update-mode') return 'replace';
+            if (key === 'hide-on-empty') return 'true';
+            return undefined;
+        });
+
+        await commentWorkflow(token);
+
+        expect(hideComment).toHaveBeenCalled();
+        expect(postComment).not.toHaveBeenCalled();
+        expect(updateComment).toHaveBeenCalled();
+        expect(findComment).toHaveBeenCalled();
+        expect(logger.debug).toHaveBeenCalledWith("Comment body is empty and hide-on-empty is true. Hiding comment.");
+    });
+
+    it('should not hide comment after update if the comment body is empty and hide-on-empty is false', async () => {
+        const mockComment = { id: 1, body: 'Existing comment' };
+        findComment.mockResolvedValue(mockComment);
+        hideComment.mockResolvedValue();
+        postComment.mockResolvedValue();
+        updateComment.mockResolvedValue({ body: '' });
+        core.getInput.mockImplementation((key) => {
+            if (key === 'comment-id') return 'Test Check';
+            if (key === 'update-mode') return 'replace';
+            if (key === 'hide-on-empty') return 'false';
+            return undefined;
+        });
+
+        await commentWorkflow(token);
+
+        expect(hideComment).not.toHaveBeenCalled();
+        expect(postComment).not.toHaveBeenCalled();
+        expect(updateComment).toHaveBeenCalled();
+        expect(findComment).toHaveBeenCalled();
+    });
+
+    it('should unhide comment after update if the comment body is empty and hide-on-empty is false and conclusion is failure', async () => {
+        const mockComment = { id: 1, body: 'Existing comment' };
+        findComment.mockResolvedValue(mockComment);
+        hideComment.mockResolvedValue();
+        postComment.mockResolvedValue();
+        updateComment.mockResolvedValue({ body: '' });
+        core.getInput.mockImplementation((key) => {
+            if (key === 'comment-id') return 'Test Check';
+            if (key === 'update-mode') return 'replace';
+            if (key === 'hide-on-empty') return 'false';
+            if (key === 'conclusion') return 'failure';
+            if (key === 'sync-conclusion') return 'true';
+            return undefined;
+        });
+
+        await commentWorkflow(token);
+
+        expect(hideComment).not.toHaveBeenCalled();
+        expect(unhideComment).toHaveBeenCalled();
+        expect(postComment).not.toHaveBeenCalled();
+        expect(updateComment).toHaveBeenCalled();
+        expect(findComment).toHaveBeenCalled();
+        expect(logger.debug).toHaveBeenCalledWith("Existing comment unhidden due to failure conclusion.");
+    });
+
+    it('should hide comment after update if the comment body is empty and hide-on-empty is true and conclusion is failure', async () => {
+        const mockComment = { id: 1, body: 'Existing comment' };
+        findComment.mockResolvedValue(mockComment);
+        hideComment.mockResolvedValue();
+        postComment.mockResolvedValue();
+        updateComment.mockResolvedValue('');
+        core.getInput.mockImplementation((key) => {
+            if (key === 'comment-id') return 'Test Check';
+            if (key === 'update-mode') return 'replace';
+            if (key === 'hide-on-empty') return 'true';
+            if (key === 'conclusion') return 'failure';
+            if (key === 'sync-conclusion') return 'true';
+            return undefined;
+        });
+
+        await commentWorkflow(token);
+
+        expect(hideComment).toHaveBeenCalled();
+        expect(unhideComment).not.toHaveBeenCalled();
+        expect(postComment).not.toHaveBeenCalled();
+        expect(updateComment).toHaveBeenCalled();
+        expect(findComment).toHaveBeenCalled();
+        expect(logger.debug).toHaveBeenCalledWith("Comment body is empty and hide-on-empty is true. Hiding comment.");
+    });
+
+    it('should not hide or unhide comment if sync-conclusion is true but conclusion is not success or failure', async () => {
+        const mockComment = { id: 1, body: 'Existing comment' };
+        findComment.mockResolvedValue(mockComment);
+        hideComment.mockResolvedValue();
+        postComment.mockResolvedValue();
+        updateComment.mockResolvedValue({ body: '' });
+        core.getInput.mockImplementation((key) => {
+            if (key === 'comment-id') return 'Test Check';
+            if (key === 'update-mode') return 'replace';
+            if (key === 'hide-on-empty') return 'false';
+            if (key === 'conclusion') return '';
+            if (key === 'sync-conclusion') return 'true';
+            return undefined;
+        });
+
+        await commentWorkflow(token);
+
+        expect(hideComment).not.toHaveBeenCalled();
+        expect(unhideComment).not.toHaveBeenCalled();
+        expect(postComment).not.toHaveBeenCalled();
+        expect(updateComment).toHaveBeenCalled();
+        expect(findComment).toHaveBeenCalled();
+        expect(logger.debug).toHaveBeenCalledWith("Conclusion is not 'success' or 'failure', cannot properly sync-conclusion.");
     });
 });

--- a/tests/comment/post-comment.test.js
+++ b/tests/comment/post-comment.test.js
@@ -101,4 +101,34 @@ describe('postComment', () => {
         await expect(postComment(octokit, 'owner', 'repo', 'identifier'))
             .rejects.toThrow("No pull request number found in the context.");
     });
+
+    it('should not create a comment if commentBody is empty and hideOnEmpty is true', async () => {
+        getCommentBody.mockReturnValueOnce('');
+
+        const result = await postComment(octokit, 'owner', 'repo', 'identifier', 'conclusion', true);
+
+        expect(logger.info).toHaveBeenCalledWith("Starting to post a comment...");
+        expect(logger.debug).toHaveBeenCalledWith("Comment body is empty. Skipping comment post.");
+        expect(getCommentBody).toHaveBeenCalled();
+        expect(octokit.rest.issues.createComment).not.toHaveBeenCalled();
+        expect(result).toBeUndefined();
+    });
+
+    it('should create a comment if commentBody is empty and hideOnEmpty is false', async () => {
+        getCommentBody.mockReturnValueOnce('');
+
+        const comment = await postComment(octokit, 'owner', 'repo', 'identifier', 'conclusion', false);
+
+        expect(logger.info).toHaveBeenCalledWith("Starting to post a comment...");
+        expect(getCommentBody).toHaveBeenCalled();
+        expect(octokit.rest.issues.createComment).toHaveBeenCalledWith({
+            owner: 'owner',
+            repo: 'repo',
+            issue_number: 42,
+            body: 'identifier\nconclusion\n'
+        });
+        expect(logger.debug).toHaveBeenCalledWith("Comment posted successfully.");
+        expect(comment).toBeDefined();
+    });
+
 });

--- a/tests/util/util.test.js
+++ b/tests/util/util.test.js
@@ -97,7 +97,31 @@ describe('getCommentBody', () => {
         fs.readFileSync.mockReturnValue('');
         expect(getCommentBody()).toBe('');
         expect(logger.debug).toHaveBeenCalledWith('Reading comment body from file: emptyfile.md');
+        expect(logger.debug).toHaveBeenCalledWith("Comment body path's file is empty.");
         expect(fs.readFileSync).toHaveBeenCalledWith('emptyfile.md', 'utf8');
+    });
+
+    it('returns empty string when directComment is empty', () => {
+        core.getInput.mockImplementation((key) => {
+            if (key === 'comment-body') return '';
+            if (key === 'render-markdown') return 'true';
+            return undefined;
+        });
+        expect(getCommentBody()).toBe('');
+        expect(logger.debug).toHaveBeenCalledWith("Neither a 'comment-body' or a 'comment-body-path' input was supplied.");
+    });
+
+    it('returns empty string when file content is empty after BOM removal', () => {
+        core.getInput.mockImplementation((key) => {
+            if (key === 'comment-body-path') return 'bom-only.md';
+            if (key === 'render-markdown') return 'true';
+            return undefined;
+        });
+        fs.readFileSync.mockReturnValue('\uFEFF');
+        expect(getCommentBody()).toBe('');
+        expect(logger.debug).toHaveBeenCalledWith('Reading comment body from file: bom-only.md');
+        expect(logger.debug).toHaveBeenCalledWith("Comment body path's file is empty.");
+        expect(fs.readFileSync).toHaveBeenCalledWith('bom-only.md', 'utf8');
     });
 
     it('throws error if file content is not a string', () => {


### PR DESCRIPTION
### Summary
\+ `..github/workflows/test-comment-inputs.yaml` -> new tests for when `hide-on-empty` is `true`
\+ `.github/workflows/test-comment-update-mode.yaml` -> new tests for when `hide-on-empty` is `true`
\+ `ci/vars/test.env` -> environment variable for new `test-comment-3.md` file
\~ `dist/index.js` -> build of new action code
\+ `src/comment/comment-workflow.js` -> if `hide-on-empty` is true, then don't create a new comment, when updating existing, hide if empty. if `hide-on-empty` is false, then proceed as previously where making empty comments is/was possible
\+ `src/comment/post-comment.js` -> `postComment` has a new `hideOnEmpty` parameter. if true, and `commentBody` is empty, then don't post comment. if either is not the case, then proceed as previously
\+ `src/comment/update-comment.js` -> `updateComment` now returns the found comment body. this is so the hide/unhide actions that come after can hide if the body is empty.
\+ `src/util/util.js` -> if `comment-body-path` is supplied, read the comment and see if the contents are empty. if so, then return an empty string
\~ `tests/README.md` -> updating to reflect the new test count
\+ `tests/` -> updating and creating new tests to reflect the changes
\+ `action.yaml` -> `hide-on-empty` input added, `conclusion` is now not required
\~ `CHANGELOG.md` -> entry for `hide-on-empty` update under `1.2.0`
\~ `README.md` -> documenting changes of `conclusion` being now optional and `hide-on-empty` input and its how it works

### Testing
- [x] `test-conclusions` label tests
- [x] `test-inputs` label tests
- [x] `test-sync-conclusions` label tests
- [x] `test-update-mode` label tests
- [x] Unit tests continue to pass with acceptable code coverage

Closes #62 