### PR TITLE
chore: updating to use node24 from node20

### DIFF
--- a/.github/workflows/test-and-coverage.yaml
+++ b/.github/workflows/test-and-coverage.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.2.0
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # CHANGELOG
+## [1.3.0] - 2026-03-24
+### Upgrade to Node 24
+#### Changed
+- Using `node24` action instead of `node20`
+
 ## [1.2.0] - 2026-02-20
 ### Don't Comment/Hide if Empty
 #### Added

--- a/action.yaml
+++ b/action.yaml
@@ -40,5 +40,5 @@ inputs:
     default: false
 
 runs:
-  using: node20
+  using: node24
   main: dist/index.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "actions-pr-comment",
-    "version": "1.1.0",
+    "version": "1.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "actions-pr-comment",
-            "version": "1.1.0",
+            "version": "1.3.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "actions-pr-comment",
-    "version": "1.1.0",
+    "version": "1.3.0",
     "description": "Action for creating and updating comments on pull requests",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Action for creating and updating comments on pull requests",
     "main": "dist/index.js",
     "scripts": {
-        "build": "esbuild src/index.js --bundle --outdir=dist --platform=node --target=node20",
+        "build": "esbuild src/index.js --bundle --outdir=dist --platform=node --target=node24",
         "lint": "eslint src/*.js",
         "test": "jest"
     },


### PR DESCRIPTION
### Summary
- \~ `.github/workflows/test-and-coverage.yaml` -> testing workflow using node-version 24
- \~ `action.yaml` -> action itself updated to use `node24`
- \~ `package.json` -> build command is told to target `node24`

### Testing
- [x] `npm run test` remains all tests passing
- [x] tested create, append, and replace update modes
  - https://github.com/colpal/cp-de-team/pull/1618#issuecomment-4113191894 